### PR TITLE
fix: add reproducible build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,8 +23,9 @@ builds:
       - -X main.name={{.ProjectName}}
       - -X main.version={{.Version}}
       - -X main.commit={{.FullCommit}}
-      - -X main.date={{.Date}}
+      - -X main.date={{.CommitDate}}
       - -X main.url={{.GitURL}}
+    mod_timestamp: "{{.CommitTimestamp}}"
     main: ./cmd/{{.ProjectName}}
 
 archives:


### PR DESCRIPTION
See detailes: GoReleaser documents

---

To make your releases, checksums and signatures reproducible, you will need to
make some (if not all) of the following modifications to the build defaults in
GoReleaser:

- Modify `ldflags`: by default `main.Date` is set to the time GoReleaser is run
  (`{{.Date}}`), you can set this to `{{.CommitDate}}` or just not pass the
  variable.
- Modify `mod_timestamp`: by default this is empty string — which means it'll be
  the compilation time, set to `{{.CommitTimestamp}}` or a constant value
  instead.
- If you do not run your builds from a consistent directory structure, pass
  `-trimpath` to `flags`.
- Remove uses of the `time` template function. This function returns a new value
  on every call and is not deterministic.
