### PR TITLE
fix: printenv context

### DIFF
--- a/.github/workflows/verify-release.yml
+++ b/.github/workflows/verify-release.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           CONTEXT: ${{ toJSON(github) }}
         run: |
-          echo "${CONTEXT}"
+          printenv CONTEXT
 
       - name: Set environment variables
         id: repository


### PR DESCRIPTION
```
Error: An error occurred trying to start process '/usr/bin/bash' with working directory '/home/runner/work/test-goreleaser/test-goreleaser'. Argument list too long
```
